### PR TITLE
Implement getAllPlayers() and setTeamName()

### DIFF
--- a/database/database.js
+++ b/database/database.js
@@ -68,6 +68,27 @@ var Database = {
 			}).catch(reject);
 		});
 	},
+
+	setTeamName: (params) => {
+		if(!params.userid){
+			throw new Error('Must specify {userid}.');
+		}
+		else if(!params.leagueid){
+			throw new Error('Must specify {leagueid}.');
+		}
+		else if(!params.team){
+			throw new Error('Must specify {team}.');
+		}
+
+		return new Promise((resolve, reject) => {
+			var ref = db.ref('leagues/' + params.leagueid + '/users/' + params.userid + '/team');
+			ref.set(params.team).then(() => {
+				resolve({
+					success: true
+				});
+			}).catch(reject);
+		});
+	},
 	
 	getUser: (params) => {
 		if(!params.userid){

--- a/database/database.js
+++ b/database/database.js
@@ -262,6 +262,7 @@ var Database = {
 						else if(meta.type === 'score'){
 							rosters[meta.uid][meta.pid].name = PLAYER_MAP[meta.pid].name;
 							rosters[meta.uid][meta.pid].ward = PLAYER_MAP[meta.pid].ward;
+							rosters[meta.uid][meta.pid].owner = meta.uid;
 							if(!rosters[meta.uid][meta.pid].scores){
 								rosters[meta.uid][meta.pid].scores = {};
 							}
@@ -320,7 +321,7 @@ var Database = {
 		});
 	},
 
-	getPlayer: (params) => {
+	getPlayer: (params, inLeague) => {
 		if(!params.playerid){
 			throw new Error('Must specify {playerid}.');
 		}
@@ -350,7 +351,8 @@ var Database = {
 				starter: false,
 				scores: {}
 			}
-			Database.getLeague(params).then((league) => {
+
+			var getPlayerCallback = (league) => {
 				var onRoster = false;
 				for(var uid in league.rosters){
 					for(var pid in league.rosters[uid]){
@@ -359,6 +361,7 @@ var Database = {
 							res.starter = league.rosters[uid][pid].starter;
 							res.scores = league.rosters[uid][pid].scores;
 							onRoster = true;
+							break;
 						}
 					}
 				}
@@ -391,6 +394,76 @@ var Database = {
 				else{
 					resolve(res);
 				}
+			}
+
+			/*
+			 * Sneaky trick to minimize promise depth of repeated getPlayer() calls
+			 * Pass in a properly structured league and use that instead of another getLeague() response
+			 * Designed for getAllPlayers() calls
+			 */
+			if(inLeague && inLeague.leagueid === params.leagueid){
+				getPlayerCallback(inLeague);
+			}
+			else{
+				Database.getLeague(params).then((league) => {
+					getPlayerCallback(inLeague);
+				}).catch(reject);
+			}
+		});
+	},
+
+	getAllPlayers: (params) => {
+		if(!params.leagueid){
+			console.warn('No {leagueid} specified.');
+		}
+		else if(!params.from){
+			throw new Error('Must specify {from}.');
+		}
+		else if(!params.to){
+			throw new Error('Must specify {to}.');
+		}
+
+		return new Promise((resolve, reject) => {
+			var res = {};
+			Database.getLeague(params).then((league) => {
+				for(var uid in league.rosters){
+					for(var rpid in league.rosters[uid]){
+						var rplayer = league.rosters[uid][rpid];
+						res[rpid] = {
+							name: rplayer.name,
+							playerid: rpid,
+							ward: rplayer.ward,
+							starter: rplayer.starter,
+							owner: uid,
+							scores: rplayer.scores
+						}
+					}
+				}
+				var freeAgentPromises = [];
+				for(var pid in PLAYER_MAP){
+					if(!(pid in res)){
+						freeAgentPromises.push(Database.getPlayer({
+							playerid: pid,
+							leagueid: params.leagueid,
+							from: params.from,
+							to: params.to
+						}, league));
+					}
+				}
+				Promise.all(freeAgentPromises).then((freeAgents) => {
+					for(var f = 0; f < freeAgents.length; f++){
+						var agent = freeAgents[f];
+						res[agent.playerid] = {
+							name: agent.name,
+							playerid: agent.playerid,
+							ward: agent.ward,
+							starter: agent.starter,
+							owner: agent.owner,
+							scores: agent.scores
+						}
+					}
+					resolve(res);
+				});
 			}).catch(reject);
 		});
 	},

--- a/database/database.js
+++ b/database/database.js
@@ -406,13 +406,13 @@ var Database = {
 			}
 			else{
 				Database.getLeague(params).then((league) => {
-					getPlayerCallback(inLeague);
+					getPlayerCallback(league);
 				}).catch(reject);
 			}
 		});
 	},
 
-	getAllPlayers: (params) => {
+	getAllPlayers: (params, inLeague) => {
 		if(!params.leagueid){
 			console.warn('No {leagueid} specified.');
 		}
@@ -425,7 +425,8 @@ var Database = {
 
 		return new Promise((resolve, reject) => {
 			var res = {};
-			Database.getLeague(params).then((league) => {
+
+			var getAllPlayersCallback = (league) => {
 				for(var uid in league.rosters){
 					for(var rpid in league.rosters[uid]){
 						var rplayer = league.rosters[uid][rpid];
@@ -464,7 +465,20 @@ var Database = {
 					}
 					resolve(res);
 				});
-			}).catch(reject);
+			}
+			
+			/*
+			 * Sneaky trick to minimize promise depth
+			 * See getPlayer() for more
+			 */
+			if(inLeague && inLeague.leagueid === params.leagueid){
+				getAllPlayersCallback(inLeague);
+			}
+			else{
+				Database.getLeague(params).then((league) => {
+					getAllPlayersCallback(league);
+				}).catch(reject);
+			}
 		});
 	},
 

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -89,7 +89,7 @@ Promise bearing data or error.
 ```
 {
 	success: true,
-	newUser: true, // Whether or not updated user is a new user
+	newUser: true // Whether or not updated user is a new user
 }
 ```
 
@@ -115,7 +115,7 @@ Promise bearing data or error.
 ```
 
 ### Database.getUserLeagues()
-Get available user information.
+Get information about the leagues a given user is part of.
 
 **Parameters**
 ```
@@ -292,6 +292,7 @@ Promise bearing data or error.
 				playerid: 'playerid0001',
 				ward: 51,
 				starter: true,
+				owner: 'testuser0001',
 				scores: {
 					'potholes': 23,
 					'graffiti': -2

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -148,6 +148,26 @@ Promise bearing data or error.
 }
 ```
 
+### Database.setTeamName()
+Set the team name for a given user in a given league.
+
+**Parameters**
+```
+{
+	userid: 'testuser0001',
+	leagueid: 'leagueid0001',
+	team: 'My New Team Name'
+}
+```
+
+**Response**
+Promise bearing data or error.
+```
+{
+	success: true
+}
+```
+
 ## Invitations
 
 ### Database.createLeagueInvitation()

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -373,6 +373,8 @@ Get a player and their scoring data for a given league.
 }
 ```
 
+* If you already have the `league` object for the given league, you can accelerate this query like so: `Database.getAllPlayers({...}, league)`.
+
 **Response**
 Promise bearing data or error.
 ```
@@ -390,6 +392,43 @@ Promise bearing data or error.
 		'graffiti': -2
 		...
 	}
+}
+```
+
+### Database.getAllPlayers()
+Get a player and their scoring data for a given league.
+
+**Parameters**
+```
+{
+	leagueid: 'leagueid0001',
+	from: 1483250400000,
+	to: 1485928800000
+}
+```
+
+* If you already have the `league` object for the given league, you can accelerate this query like so: `Database.getAllPlayers({...}, league)`.
+
+**Response**
+Promise bearing data or error.
+```
+{
+	playerid0001: {
+		playerid: 'playerid0001',
+		leagueid: 'leagueid0001',
+		from: 1483250400000,
+		to: 1485928800000,
+		owner: 'testuser0001', // or false if not on rosters in the league
+		name: 'Test Player',
+		ward: 51,
+		starter: true,
+		scores: {
+			'potholes': 23,
+			'graffiti': -2
+			...
+		}
+	}
+	...
 }
 ```
 

--- a/database/index.html
+++ b/database/index.html
@@ -63,6 +63,18 @@
 				for(var uid in league.rosters){
 					renderRosters(league.rosters[uid], uid, league.users);
 				}
+				Database.getAllPlayers({
+					leagueid: league.leagueid,
+					from: league.from,
+					to: league.to
+				}).then((allPlayers) => {
+					console.log('Test Get All Players Response');
+					console.log(allPlayers);
+					renderPlayerScores(allPlayers, league);
+				}).catch((err2) => {
+					console.log('Test Get All Players Response');
+					console.error(err2);
+				});
 			}).catch((err) => {
 				console.log('Test Get League Response');
 				console.error(err);

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -95,3 +95,74 @@ function renderSchedule(schedule, league, userMap){
 	div.appendChild(table);
 	document.body.appendChild(div);
 }
+
+function renderPlayerScores(roster, league, sortFn){
+	var dateFormat = 'dddd, M/D/YYYY';
+
+	var div = document.createElement('div');
+	var h2 = document.createElement('h2');
+		h2.innerText = 'All Players: ' + league.name;
+	var para = document.createElement('p');
+		para.innerText = 'Scores from ' + moment(league.from).format(dateFormat) + ' to ' + moment(league.to).format(dateFormat) + ':';
+	
+	var table = document.createElement('table');
+	var scoreHeaders = Object.keys(Database.Scoring.DATASETS);
+	var hdr = '';
+		hdr += '<tr>'
+		hdr += '<td class="player-name">Player</td>'
+		hdr += '<td class="center">Ward</td>'
+	for(var h = 0; h < scoreHeaders.length; h++){
+		hdr += '<td class="center">' + Database.Scoring.DATASET_NAMES[scoreHeaders[h]] + '</td>'
+	}
+		hdr += '<td class="center">Score</td>'
+		hdr += '<td>Team</td>'
+		hdr += '<td>Status</td>'
+		hdr += '</tr>'
+
+	var sumScores = (scoreMap) => {
+		var outSum = 0;
+		for(var dt in scoreMap){
+			outSum += scoreMap[dt];
+		}
+		return outSum;
+	}
+	var starterSort = (a, b) => {
+		var as = a.starter ? 1 : 0;
+		var bs = b.starter ? 1 : 0;
+		return bs - as;
+	}
+	var scoreSort = (a, b) => {
+		return sumScores(b.scores) - sumScores(a.scores);
+	}
+	var defaultSort = scoreSort;
+	var sorter = sortFn || defaultSort;
+
+	var rosterList = Object.keys(roster).map((pid) => {
+		roster[pid].playerid = pid;
+		return roster[pid];
+	}).sort(sorter);
+
+	for(var p = 0; p < rosterList.length; p++){
+	var player = rosterList[p];
+	var score = 0;
+	var row = '';
+		row += '<tr>'
+		row += '<td>' + player.name + '</td>'
+		row += '<td class="center">' + player.ward + '</td>'
+	for(var h = 0; h < scoreHeaders.length; h++){
+		row += '<td class="center">' + player.scores[scoreHeaders[h]] + '</td>'
+		score += player.scores[scoreHeaders[h]]
+	}
+		row += '<td class="center">' + score + '</td>'
+		row += '<td>' + (player.owner ? league.users[player.owner].team : 'None') + '</td>'
+		row += '<td>' + (player.owner ? (player.starter ? 'Starting' : 'Benched') : 'Free Agent') + '</td>'
+		row += '</tr>';
+		hdr += row;
+	}
+
+	table.innerHTML = hdr;
+	div.appendChild(h2);
+	div.appendChild(para);
+	div.appendChild(table);
+	document.body.appendChild(div);
+}


### PR DESCRIPTION
In preparation for practice games, the application can now request the data and scores for all players in a league, not just those on rosters. Users can also set and update their team names. Refer to the database documentation for usage.

Note that some database functions now allow secondary arguments to reduce the number of promises that need to be made internally. Example use cases include:

* When you already have a league object and just want to query more players in that league
* When you already have a league object and want to query the same players over a different date range

This may become more frequent if response time lags. The documentation shows how to give the secondary argument.