### PR TITLE
Lock Rosters

### DIFF
--- a/database/database.js
+++ b/database/database.js
@@ -626,6 +626,7 @@ var Database = {
 				var res = params.on > lockTime;
 				resolve({
 					locked: res,
+					lockTime: lockTime,
 					match: match
 				});
 			}).catch(reject);

--- a/database/database.js
+++ b/database/database.js
@@ -37,6 +37,12 @@ var Database = {
 
 	LOCK_ROSTERS_AFTER: (6 / 7), // Locks rosters 6/7 of the way through the match
 
+	getLockTime: (match) => {
+		var duration = match.end - match.start;
+		var lockTime = match.start + (Database.LOCK_ROSTERS_AFTER * duration);
+		return lockTime;
+	},
+
 	updateUser: (params) => {
 		if(!params.userid){
 			throw new Error('Must specify {userid}.');
@@ -600,6 +606,29 @@ var Database = {
 					reject('There are no matches on {' + new Date(params.on) + '} in league {leagueid: ' + params.leagueid + '}.');
 				}
 			})
+		});
+	},
+
+	isLocked: (params) => {
+		if(!params.userid){
+			throw new Error('Must specify {userid}.');
+		}
+		else if(!params.leagueid){
+			throw new Error('Must specify {leagueid}.');
+		}
+		else if(!params.on){
+			throw new Error('Must specify {on}.');
+		}
+
+		return new Promise((resolve, reject) => {
+			Database.getMatch(params).then((match) => {
+				var lockTime = Database.getLockTime(match);
+				var res = params.on > lockTime;
+				resolve({
+					locked: res,
+					match: match
+				});
+			}).catch(reject);
 		});
 	},
 

--- a/database/database.js
+++ b/database/database.js
@@ -581,6 +581,7 @@ var Database = {
 								res.end = game.end;
 								res.home = game.home;
 								res.away = game.away;
+								res.week = (parseInt(week, 10) + 1);
 								break;
 							}
 						}

--- a/database/database.js
+++ b/database/database.js
@@ -35,6 +35,8 @@ var Database = {
 	Auth: DatabaseAuth(DatabaseFirebase),
 	Scoring: Scoring,
 
+	LOCK_ROSTERS_AFTER: (6 / 7), // Locks rosters 6/7 of the way through the match
+
 	updateUser: (params) => {
 		if(!params.userid){
 			throw new Error('Must specify {userid}.');

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -525,6 +525,7 @@ Promise bearing data or error.
 ```
 	{
 		locked: true,
+		lockTime: 1483220400000,
 		match: {
 			userid: 'testuser0001',
 			leagueid: 'leagueid0001',
@@ -537,6 +538,8 @@ Promise bearing data or error.
 		}
 	}
 ```
+
+* Property `lockTime` in the response is the timestamp at which the roster locks for the current match. It is returned regardless of whether or not the roster is locked. Example use case: if the application wants to let the user know when their roster will lock, or how much time they have left to make changes.
 
 ### Database.movePlayer()
 Switch a starting player with a benched player on the roster of the given user.

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -508,6 +508,36 @@ Promise bearing data or error.
 }
 ```
 
+### Database.isLocked()
+Determine whether or not the given user in the given league can edit their roster. This function is used internally with all methods that affect user rosters and will reject the transaction if the roster is locked.
+
+**Parameters**
+```
+{
+	userid: 'testuser0001',
+	leagueid: 'leagueid0001',
+	on: Date.now()
+}
+```
+
+**Response**
+Promise bearing data or error.
+```
+	{
+		locked: true,
+		match: {
+			userid: 'testuser0001',
+			leagueid: 'leagueid0001',
+			on: 1483250400000,
+			home: 'testuser0001',
+			away: 'testuser0002',
+			start: 1483250400000,
+			end: 1485928800000,
+			week: 2
+		}
+	}
+```
+
 ### Database.movePlayer()
 Switch a starting player with a benched player on the roster of the given user.
 

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -603,10 +603,12 @@ Promise bearing data or error.
 		home: 'testuser0001',
 		away: 'testuser0002',
 		start: 1483250400000,
-		end: 1485928800000
+		end: 1485928800000,
+		week: 2
 	}
 ```
 
 * Properties `start` and `end` represent the start and ending times of the match.
+* Property `week` indicates the week in the season the match is part of.
 
 **Note:** _The process to determine who wins a past match and save that result are still under development._

--- a/database/index.html
+++ b/database/index.html
@@ -48,12 +48,13 @@
 
 			var l1 = '-KdIiWEUj7_toD3MKMO_';
 			var l2 = '-KdJnBQC6hc7OF9FguyQ';
+			var l3 = '-KdiofxVNZK1_QDoI3cN';
 
 			var Database = InitDatabase();
 
 			// Testing Get League Response
 			Database.getLeague({
-				leagueid: l1,
+				leagueid: l3,
 				from: new Date('2/12/2017').getTime(),
 				to: Date.now()
 			}).then((league) => {
@@ -92,7 +93,7 @@
 
 			Database.getMatch({
 				userid: 'testuser0002',
-				leagueid: l1,
+				leagueid: l3,
 				on: Date.now()
 			}).then((res) => {
 				console.log('Test Get Match Response');
@@ -104,7 +105,7 @@
 
 			// Comment out after testing once: changes persist
 			/*Database.movePlayer({
-				leagueid: l1,
+				leagueid: l3,
 				userid: 'testuser0002',
 				sit: 'playerid0020',
 				start: 'playerid0031'

--- a/database/league.js
+++ b/database/league.js
@@ -22,6 +22,9 @@ var League = {
 			newUsers.push(botid);
 			res = newUsers;
 		}
+		else{
+			res = users;
+		}
 		return res;
 	},
 
@@ -113,7 +116,13 @@ var League = {
 	 */
 	generateRosters: (users, players) => {
 		var rosterMap = {};
-		if(users.length < 1){
+		if(!users){
+			throw new Error('No userids provided.');
+		}
+		if(!players){
+			throw new Error('No players provided.');
+		}
+		else if(users.length < 1){
 			throw new Error('List of userids is empty.');
 		}
 		else if(users.length % 2 !== 0){

--- a/database/match.html
+++ b/database/match.html
@@ -56,17 +56,37 @@
 			var toDate = new Date('2/7/2017').getTime()
 			var onDate = new Date('2/5/2017').getTime()
 
-			Database.getMatch({
-				userid: 'testuser0002',
-				leagueid: l1,
-				on: onDate
-			}).then((match) => {
-				console.log('Test Get Match Response');
-				console.log(res);
-			}).catch((err) => {
-				console.log('Test Get Match Response');
-				console.error(err);
-			});
+			function loadMatch(league){
+				Database.getMatch({
+					userid: 'testuser0002',
+					leagueid: l1,
+					on: onDate
+				}).then((match) => {
+					console.log('Test Get Match Response');
+					console.log(match);
+					Promise.all([
+						Database.getRoster({
+							userid: match.home,
+							leagueid: l1,
+							from: match.start,
+							to: match.end
+						}),
+						Database.getRoster({
+							userid: match.away,
+							leagueid: l1,
+							from: match.start,
+							to: match.end
+						})
+					]).then((participants) => {
+						var homeUser = participants[0];
+						var awayUser = participants[1];
+						renderBoxScore(match, homeUser, awayUser, league)
+					});
+				}).catch((err) => {
+					console.log('Test Get Match Response');
+					console.error(err);
+				});
+			}
 
 			Database.getLeague({
 				leagueid: l1,
@@ -75,6 +95,8 @@
 			}).then((league) => {
 				console.log('Test Get League Response');
 				console.log(league);
+				loadMatch(league);
+				//
 				renderSchedule(league.schedule, league, league.users);
 				for(var uid in league.rosters){
 					renderRosters(league.rosters[uid], uid, league);

--- a/database/match.html
+++ b/database/match.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Fantasy Civics</title>
+		<!--<link rel="icon" type="img/png" href="style/favicon.png" style="width:30px;">-->
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<script src="https://www.gstatic.com/firebasejs/3.6.9/firebase.js"></script>
+		<style>
+
+			table td {
+				padding-right: 10px;
+			}
+
+			.center {
+				text-align: center;
+			}
+
+			td.center {
+				width: 90px;
+			}
+
+			td.player-name {
+				width: 180px;
+			}
+
+		</style>
+	</head>
+
+	<body>
+
+		<h1>Database Testing Suite</h1>
+
+		<script type="text/javascript" src="../assets/promise.min.js"></script>
+		<script type="text/javascript" src="../assets/moment.min.js"></script>
+		<script type="text/javascript" src="../assets/jquery-3.1.1.min.js"></script>
+		<script type="text/javascript" src="../lib/util.js"></script>
+
+		<!-- Five Internal Libraries  Required for Database Usage -->
+		<script type="text/javascript" src="./player.js"></script>
+		<script type="text/javascript" src="./league.js"></script>
+		<script type="text/javascript" src="./scoring.js"></script>
+		<script type="text/javascript" src="./auth.js"></script>
+		<script type="text/javascript" src="./database.js"></script>
+
+		<script type="text/javascript" src="./test-views.js"></script>
+		
+		<script type="text/javascript">
+
+			var l1 = '-KdIiWEUj7_toD3MKMO_';
+			var l2 = '-KdJnBQC6hc7OF9FguyQ';
+			var test = '-KdYWQQsWkAVuLiIoAwN';
+
+			var Database = InitDatabase();
+
+			var fromDate = new Date('2/4/2017').getTime();
+			var toDate = new Date('2/7/2017').getTime()
+			var onDate = new Date('2/5/2017').getTime()
+
+			Database.getMatch({
+				userid: 'testuser0002',
+				leagueid: l1,
+				on: onDate
+			}).then((match) => {
+				console.log('Test Get Match Response');
+				console.log(res);
+			}).catch((err) => {
+				console.log('Test Get Match Response');
+				console.error(err);
+			});
+
+			Database.getLeague({
+				leagueid: l1,
+				from: fromDate,
+				to: toDate
+			}).then((league) => {
+				console.log('Test Get League Response');
+				console.log(league);
+				renderSchedule(league.schedule, league, league.users);
+				for(var uid in league.rosters){
+					renderRosters(league.rosters[uid], uid, league);
+				}
+				Database.getAllPlayers({
+					leagueid: league.leagueid,
+					from: league.from,
+					to: league.to
+				}).then((allPlayers) => {
+					console.log('Test Get All Players Response');
+					renderPlayerScores(allPlayers, league);
+				}).catch((err2) => {
+					console.log('Test Get All Players Response');
+					console.error(err2);
+				});
+			}).catch((err) => {
+				console.log('Test Get League Response');
+				console.error(err);
+			});
+
+			// Comment out after testing once: changes persist
+			/*Database.movePlayer({
+				leagueid: l1,
+				userid: 'testuser0002',
+				sit: 'playerid0020',
+				start: 'playerid0031'
+			}).then((res) => {
+				console.log('Test Move Player Request');
+				console.log(res);
+			}).catch((err) => {
+				console.log('Test Move Player Request');
+				console.error(err);
+			});*/
+
+			// Comment out after testing once: changes persist
+			/*Database.createLeague({
+				name: 'ChiHackNight Test League',
+				start: new Date('1/1/2017').getTime(),
+				end: new Date('1/23/2017').getTime(),
+				users: ['testuser0001', 'testuser0002', 'testuser0003'],
+				weeks: 3
+			}).then((response) => {
+				console.log('Testing Create League');
+				console.log(response);
+			}).catch((err) => {
+				console.log('Testing Create League');
+				console.error(err);
+			});*/
+
+		</script>
+	
+	</body>
+
+</html>

--- a/database/match.html
+++ b/database/match.html
@@ -99,9 +99,9 @@
 				console.log(league);
 				loadMatch(league);
 				//
-				//renderSchedule(league.schedule, league, league.users);
+				renderSchedule(league.schedule, league, league.users);
 				for(var uid in league.rosters){
-					//renderRosters(league.rosters[uid], uid, league);
+					renderRosters(league.rosters[uid], uid, league);
 				}
 				Database.getAllPlayers({
 					leagueid: league.leagueid,
@@ -109,7 +109,7 @@
 					to: league.to
 				}).then((allPlayers) => {
 					console.log('Test Get All Players Response');
-					//renderPlayerScores(allPlayers, league);
+					renderPlayerScores(allPlayers, league);
 				}).catch((err2) => {
 					console.log('Test Get All Players Response');
 					console.error(err2);

--- a/database/match.html
+++ b/database/match.html
@@ -49,30 +49,31 @@
 			var l1 = '-KdIiWEUj7_toD3MKMO_';
 			var l2 = '-KdJnBQC6hc7OF9FguyQ';
 			var test = '-KdYWQQsWkAVuLiIoAwN';
+			var l3 = '-KdiofxVNZK1_QDoI3cN';
 
 			var Database = InitDatabase();
 
-			var fromDate = new Date('2/4/2017').getTime();
-			var toDate = new Date('2/7/2017').getTime()
-			var onDate = new Date('2/5/2017').getTime()
+			var fromDate = new Date('2/19/2017').getTime();
+			var toDate = new Date('2/24/2017').getTime()
+			var onDate = Date.now();//new Date('2/24/2017').getTime()
 
 			function loadMatch(league){
 				Database.getMatch({
 					userid: 'testuser0002',
-					leagueid: l1,
+					leagueid: l3,
 					on: onDate
 				}).then((match) => {
 					console.log('Test Get Match Response');
 					console.log(match);
 					var p1 = Database.getRoster({
 						userid: match.home,
-						leagueid: l1,
+						leagueid: l3,
 						from: match.start,
 						to: match.end
 					});
 					var p2 = Database.getRoster({
 						userid: match.away,
-						leagueid: l1,
+						leagueid: l3,
 						from: match.start,
 						to: match.end
 					});
@@ -91,7 +92,7 @@
 			}
 
 			Database.getLeague({
-				leagueid: l1,
+				leagueid: l3,
 				from: fromDate,
 				to: toDate
 			}).then((league) => {
@@ -103,50 +104,10 @@
 				for(var uid in league.rosters){
 					renderRosters(league.rosters[uid], uid, league);
 				}
-				Database.getAllPlayers({
-					leagueid: league.leagueid,
-					from: league.from,
-					to: league.to
-				}).then((allPlayers) => {
-					console.log('Test Get All Players Response');
-					renderPlayerScores(allPlayers, league);
-				}).catch((err2) => {
-					console.log('Test Get All Players Response');
-					console.error(err2);
-				});
 			}).catch((err) => {
 				console.log('Test Get League Response');
 				console.error(err);
 			});
-
-			// Comment out after testing once: changes persist
-			/*Database.movePlayer({
-				leagueid: l1,
-				userid: 'testuser0002',
-				sit: 'playerid0020',
-				start: 'playerid0031'
-			}).then((res) => {
-				console.log('Test Move Player Request');
-				console.log(res);
-			}).catch((err) => {
-				console.log('Test Move Player Request');
-				console.error(err);
-			});*/
-
-			// Comment out after testing once: changes persist
-			/*Database.createLeague({
-				name: 'ChiHackNight Test League',
-				start: new Date('1/1/2017').getTime(),
-				end: new Date('1/23/2017').getTime(),
-				users: ['testuser0001', 'testuser0002', 'testuser0003'],
-				weeks: 3
-			}).then((response) => {
-				console.log('Testing Create League');
-				console.log(response);
-			}).catch((err) => {
-				console.log('Testing Create League');
-				console.error(err);
-			});*/
 
 		</script>
 	

--- a/database/match.html
+++ b/database/match.html
@@ -64,19 +64,21 @@
 				}).then((match) => {
 					console.log('Test Get Match Response');
 					console.log(match);
+					var p1 = Database.getRoster({
+						userid: match.home,
+						leagueid: l1,
+						from: match.start,
+						to: match.end
+					});
+					var p2 = Database.getRoster({
+						userid: match.away,
+						leagueid: l1,
+						from: match.start,
+						to: match.end
+					});
 					Promise.all([
-						Database.getRoster({
-							userid: match.home,
-							leagueid: l1,
-							from: match.start,
-							to: match.end
-						}),
-						Database.getRoster({
-							userid: match.away,
-							leagueid: l1,
-							from: match.start,
-							to: match.end
-						})
+						p1,
+						p2
 					]).then((participants) => {
 						var homeUser = participants[0];
 						var awayUser = participants[1];
@@ -97,9 +99,9 @@
 				console.log(league);
 				loadMatch(league);
 				//
-				renderSchedule(league.schedule, league, league.users);
+				//renderSchedule(league.schedule, league, league.users);
 				for(var uid in league.rosters){
-					renderRosters(league.rosters[uid], uid, league);
+					//renderRosters(league.rosters[uid], uid, league);
 				}
 				Database.getAllPlayers({
 					leagueid: league.leagueid,
@@ -107,7 +109,7 @@
 					to: league.to
 				}).then((allPlayers) => {
 					console.log('Test Get All Players Response');
-					renderPlayerScores(allPlayers, league);
+					//renderPlayerScores(allPlayers, league);
 				}).catch((err2) => {
 					console.log('Test Get All Players Response');
 					console.error(err2);

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -201,8 +201,7 @@ var scoreFromMap = (map) => {
 function renderBoxScore(match, home, away, league){
 	var div = document.createElement('div');
 	var h2 = document.createElement('h2');
-		var wkNo = 2;
-		h2.innerText = 'Week ' + wkNo + ' Matchup';
+		h2.innerText = 'Week ' + match.week + ' Matchup';
 	var rows = [];
 	var homeRoster = Object.keys(home.players).map((pid) => { return home.players[pid]; }).sort(rosterSort);
 	var awayRoster = Object.keys(away.players).map((pid) => { return away.players[pid]; }).sort(rosterSort);

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -175,7 +175,10 @@ function createDOMTable(headers, rows){
 		return '<tr>' + list.map((val) => { return '<td>' + val + '</td>'}).join('') + '</tr>';
 	}
 	var table = document.createElement('table');
-	var html = listToRow(headers);
+	var html = '';
+	if(headers){
+		html += listToRow(headers);
+	}
 	for(var r = 0; r < rows.length; r++){
 		html += listToRow(rows[r]);
 	}
@@ -183,14 +186,39 @@ function createDOMTable(headers, rows){
 	return table;
 }
 
+var rosterSort = (a, b) => {
+	var as = a.starter ? 1 : 0;
+	var bs = b.starter ? 1 : 0;
+	return bs - as;
+}
+
+var scoreFromMap = (map) => {
+	var score = 0;
+	Object.keys(map).map((key) => { score += map[key]; return 0; })
+	return score;
+}
+
 function renderBoxScore(match, home, away, league){
 	var div = document.createElement('div');
 	var h2 = document.createElement('h2');
 		h2.innerText = 'All Players: ' + league.name;
-	var headers = [];
+	var headers = ['Player', 'Score', ' - ', 'Score', 'Player'];
 	var rows = [];
-	var table = createDOMTable(headers, rows);
+	var homeRoster = Object.keys(home.players).map((pid) => { return home.players[pid]; }).sort(rosterSort);
+	var awayRoster = Object.keys(away.players).map((pid) => { return away.players[pid]; }).sort(rosterSort);
+	for(var j = 0; j < homeRoster.length; j++){
+		var homePlayer = homeRoster[j];
+		var awayPlayer = awayRoster[j];
+		rows.push([
+			homePlayer.name,
+			scoreFromMap(homePlayer.scores),
+			' - ',
+			scoreFromMap(awayPlayer.scores),
+			awayPlayer.name
+		]);
+	}
+	var playerTable = createDOMTable(headers, rows);
 	div.appendChild(h2);
-	div.appendChild(table);
+	div.appendChild(playerTable);
 	document.body.appendChild(div);	
 }

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -169,3 +169,28 @@ function renderPlayerScores(roster, league, sortFn){
 	div.appendChild(table);
 	document.body.appendChild(div);
 }
+
+function createDOMTable(headers, rows){
+	function listToRow(list){
+		return '<tr>' + list.map((val) => { return '<td>' + val + '</td>'}).join('') + '</tr>';
+	}
+	var table = document.createElement('table');
+	var html = listToRow(headers);
+	for(var r = 0; r < rows.length; r++){
+		html += listToRow(rows[r]);
+	}
+	table.innerHTML = html;
+	return table;
+}
+
+function renderBoxScore(match, home, away, league){
+	var div = document.createElement('div');
+	var h2 = document.createElement('h2');
+		h2.innerText = 'All Players: ' + league.name;
+	var headers = [];
+	var rows = [];
+	var table = createDOMTable(headers, rows);
+	div.appendChild(h2);
+	div.appendChild(table);
+	document.body.appendChild(div);	
+}

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -201,23 +201,69 @@ var scoreFromMap = (map) => {
 function renderBoxScore(match, home, away, league){
 	var div = document.createElement('div');
 	var h2 = document.createElement('h2');
-		h2.innerText = 'All Players: ' + league.name;
-	var headers = ['Player', 'Score', ' - ', 'Score', 'Player'];
+		var wkNo = 2;
+		h2.innerText = 'Week ' + wkNo + ' Matchup';
 	var rows = [];
 	var homeRoster = Object.keys(home.players).map((pid) => { return home.players[pid]; }).sort(rosterSort);
 	var awayRoster = Object.keys(away.players).map((pid) => { return away.players[pid]; }).sort(rosterSort);
+	var scores = {
+		home: {
+			lineup: 0,
+			bench: 0
+		},
+		away: {
+			lineup: 0,
+			bench: 0
+		}
+	}
+	var startingLineup = true;
+			rows.push([league.users[match.home].team, '', '', league.users[match.away].team, '']);
+			rows.push(['Player', 'Score', ' - ', 'Score', 'Player']);
+			rows.push(['Starting Lineup', '', '', 'Starting Lineup', '']);
 	for(var j = 0; j < homeRoster.length; j++){
 		var homePlayer = homeRoster[j];
 		var awayPlayer = awayRoster[j];
+		if(!homePlayer.starter && startingLineup){
+			startingLineup = false;
+			rows.push([
+				'',
+				scores.home.lineup,
+				'',
+				'',
+				scores.away.lineup
+			]);
+			rows.push([
+				'Bench',
+				'',
+				'',
+				'Bench',
+				''
+			]);
+		}
 		rows.push([
 			homePlayer.name,
 			scoreFromMap(homePlayer.scores),
 			' - ',
-			scoreFromMap(awayPlayer.scores),
-			awayPlayer.name
+			awayPlayer.name,
+			scoreFromMap(awayPlayer.scores)
 		]);
+		if(startingLineup){
+			scores.home.lineup += scoreFromMap(homePlayer.scores);
+			scores.away.lineup += scoreFromMap(awayPlayer.scores);
+		}
+		else{
+			scores.home.bench += scoreFromMap(homePlayer.scores);
+			scores.away.bench += scoreFromMap(awayPlayer.scores);
+		}
 	}
-	var playerTable = createDOMTable(headers, rows);
+			rows.push([
+				'',
+				scores.home.bench,
+				'',
+				'',
+				scores.away.bench
+			]);
+	var playerTable = createDOMTable(false, rows);
 	div.appendChild(h2);
 	div.appendChild(playerTable);
 	document.body.appendChild(div);	

--- a/database/test-views.js
+++ b/database/test-views.js
@@ -70,6 +70,7 @@ function renderSchedule(schedule, league, userMap){
 		hdr += '<td></td>'
 		hdr += '<td>Home</td>'
 		hdr += '<td>Start</td>'
+		hdr += '<td>Lock</td>'
 		hdr += '<td>End</td>'
 		hdr += '</tr>';
 	for(var w = 0; w < schedule.length; w++){
@@ -84,6 +85,7 @@ function renderSchedule(schedule, league, userMap){
 		row += '<td> @ </td>'
 		row += '<td>' + home.name + '</td>'
 		row += '<td>' + moment(games[h].start).format(dateFormat) + '</td>'
+		row += '<td>' + moment(Database.getLockTime(games[h])).format(dateFormat) + '</td>'
 		row += '<td>' + moment(games[h].end).format(dateFormat) + '</td>'
 		row += '<tr>'
 		hdr += row;


### PR DESCRIPTION
Tweak `Database.LOCK_ROSTERS_AFTER` to set the point (between 0 and 1) during a match where rosters can no longer be changed. Exposes `Database.isLocked()` function for application to check if rosters are locked as well as get the price `lockTime` for the current match. Locking checks are also implemented internally in all functions that edit rosters. See documentation for usage.