### PR TITLE
Get current user and page linking fix

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -20,7 +20,9 @@ function viewOutcome(){
 	var leagueid = USER.leagueid;
 	var sim = USER.rosterdate;
 	var timestamp = sim.thisfrom + (0.5 * (sim.thisto - sim.thisfrom));
-	var url = document.location.origin + '/app/scores.html' + '?time=' + timestamp + '&league=' + leagueid
+	var uParts = document.location.pathname.split('/');
+	var pathname = '/' + uParts.slice(0, uParts.length - 1).join('/');
+	var url = document.location.origin + pathname + '/scores.html' + '?time=' + timestamp + '&league=' + leagueid;
 	document.location = url;
 }
 
@@ -645,8 +647,6 @@ function InitApplication() {
 			}).then((matchOutcome) => {
 				if (matchOutcome.success) {
 					log("Success");
-					var otc = document.getElementById('outcome');
-					otc.disabled = false;
 				}
 			}).catch((err) => {
 				log(err);

--- a/app/join.js
+++ b/app/join.js
@@ -5,7 +5,11 @@ var WATCH_LEAGUES = {};
 var YOUR_LEAGUES = {}
 
 Database.Auth.getCurrentUser().then((user) => {
-	login(user);
+	Database.getUser({
+		userid: user.userid
+	}).then((userData) => {
+		login(userData);
+	}).catch(displayError);
 }).catch((err) => {
 	if(err === 'No user currently authenticated.'){
 		displayMessage('Log in in to play Fantasy Civics!');

--- a/app/scores.js
+++ b/app/scores.js
@@ -108,36 +108,32 @@ function render(){
 		var match = score.match;
 			match.winner = score.winner;
 
+		var homeUser = {
+			userid: match.home,
+			leagueid: LEAGUE_ID,
+			players: score.rosters[match.home],
+			from: match.start,
+			to: match.end
+		}
+		var awayUser = {
+			userid: match.away,
+			leagueid: LEAGUE_ID,
+			players: score.rosters[match.away],
+			from: match.start,
+			to: match.end
+		}
+
 		Database.getLeague({
 			leagueid: LEAGUE_ID,
 			from: match.start,
 			to: match.end
 		}).then((league) => {
 
-			var p1 = Database.getRoster({
-				userid: match.home,
-				leagueid: league.leagueid,
-				from: match.start,
-				to: match.end
-			});
-			var p2 = Database.getRoster({
-				userid: match.away,
-				leagueid: league.leagueid,
-				from: match.start,
-				to: match.end
-			});
-			Promise.all([
-				p1,
-				p2
-			]).then((participants) => {
-				var homeUser = participants[0];
-				var awayUser = participants[1];
-				var boxScoreDiv = renderBoxScore(match, homeUser, awayUser, league);
-				var parent = document.getElementById('box-score');
-				parent.appendChild(boxScoreDiv);
-				var load = document.getElementById('loading-box-score');
-				load.style.display = 'none';
-			});
+			var boxScoreDiv = renderBoxScore(match, homeUser, awayUser, league);
+			var parent = document.getElementById('box-score');
+			parent.appendChild(boxScoreDiv);
+			var load = document.getElementById('loading-box-score');
+			load.style.display = 'none';
 
 			Database.getLeaderboard({
 				leagueid: league.leagueid

--- a/database/auth.js
+++ b/database/auth.js
@@ -13,7 +13,7 @@
 });*/
 
 
-function DatabaseAuth(FirebaseInstance){
+function DatabaseAuth(FirebaseInstance, DatabaseInstance){
 	
 	var Auth = {
 
@@ -22,6 +22,7 @@ function DatabaseAuth(FirebaseInstance){
 				var provider = new firebase.auth.GoogleAuthProvider();
 				FirebaseInstance.auth().signInWithPopup(provider).then((data) => {
 					var result = data.user;
+					localStorage.setItem('fantasy-civics-userid', result.uid);
 					resolve({
 						userid: result.uid,
 						name: result.displayName,
@@ -33,18 +34,16 @@ function DatabaseAuth(FirebaseInstance){
 		},
 
 		signOutUser: () => {
+			localStorage.removeItem('fantasy-civics-userid');
 			return FirebaseInstance.auth().signOut();
 		},
 
 		getCurrentUser: () => {
 			return new Promise((resolve, reject) => {
-				var result = FirebaseInstance.auth().currentUser;
-				if(result){
+				var userid = localStorage.getItem('fantasy-civics-userid');
+				if(userid){
 					resolve({
-						userid: result.uid,
-						name: result.displayName,
-						email: result.email,
-						image: result.photoURL
+						userid: userid
 					});
 				}
 				else{

--- a/database/documentation.md
+++ b/database/documentation.md
@@ -83,7 +83,7 @@ Sign out user.
 Promise representing success or bearing error.
 
 ### Database.Auth.getCurrentUser()
-Get data for the user who is currently authenticated, if any.
+Get the userid for the user who is currently authenticated, if any. Call `Database.getUser()` with the userid to get additional information.
 
 **Parameters**
 `void`
@@ -92,10 +92,7 @@ Get data for the user who is currently authenticated, if any.
 Promise bearing data or error.
 ```
 {
-	userid: 'testuser0001',
-	name: 'Test User',
-	email: 'test@fantasycivics.edu',
-	image: 'https://fantasycivics.edu/image.png'
+	userid: 'testuser0001'
 }
 ```
 


### PR DESCRIPTION
Fixes issues #34 and #36.

@GeliClub, now you need to use `Database.getCurrentUser()` in the application. It only provides the `userid` on purpose, you need to fetch the rest of the user data using the `Database.getUser()` function. It's not a good idea to store many pieces of user information in localStorage, because they are hard to manage: if a new user logs in but doesn't have a picture or a display name, you could accidentally display an old picture to them, or a name from another account.